### PR TITLE
Fix build errors when compiling with gcc 15 and cmake 4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,12 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.5..4.0)
 
 project(Argo)
 
+include(CTest)
+
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -Wall -std=c++11")
+
+file(GLOB HEADERS "*.hpp")
 
 add_library(argo
         json.cpp utf8.cpp lexer.cpp reader.cpp stream_reader.cpp
@@ -31,8 +35,10 @@ else (DOXYGEN_FOUND)
     message("Doxygen need to be installed to generate the Argo documentation")
 endif (DOXYGEN_FOUND)
 
-add_custom_command(
-    TARGET json_test
-    POST_BUILD COMMAND "${CMAKE_BINARY_DIR}/json_test"
-    WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
-    COMMENT "Running unit tests...")
+add_test(
+    NAME json_test
+    COMMAND "${CMAKE_BINARY_DIR}/json_test"
+    WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}")
+
+install(TARGETS argo)
+install(FILES ${HEADERS} DESTINATION include/argo)

--- a/json_invalid_key_exception.cpp
+++ b/json_invalid_key_exception.cpp
@@ -30,12 +30,14 @@
 
 using namespace NAMESPACE;
 
+static const char invalid_key_header[] = "invalid object key: ";
+
 json_invalid_key_exception::json_invalid_key_exception(exception_type et, const std::string &key) noexcept : json_exception(et)
 {
     if (et == invalid_key_e)
     {
-        strncpy(m_message, "invalid object key: ", max_message_length);
-        strncpy(m_message, key.c_str(), max_message_length);
+        strncpy(m_message, invalid_key_header, max_message_length);
+        strncpy(m_message, key.c_str(), max_message_length - (sizeof(invalid_key_header) - 1));
     }
     else
     {

--- a/json_io_exception.cpp
+++ b/json_io_exception.cpp
@@ -57,15 +57,17 @@ const char *json_io_exception::get_main_message()
 
 json_io_exception::json_io_exception(exception_type et) noexcept : json_exception(et)
 {
-    strncpy(m_message, get_main_message(), max_message_length);
+    strncpy(m_message, get_main_message(), max_message_length - 1);
 }
 
 json_io_exception::json_io_exception(exception_type et, int posix_errno) noexcept : json_exception(et)
 {
+    // strerror_r may not always write to the provided buffer, it may return a pointer to
+    // a static string instead.
     char buffer[max_message_length - 3];
-    strerror_r(posix_errno, buffer, max_message_length - 3);
+    const char *errmsg = strerror_r(posix_errno, buffer, max_message_length - 3);
 
-    snprintf(m_message, max_message_length, "%s : %s", get_main_message(), buffer);
+    snprintf(m_message, max_message_length, "%s : %s", get_main_message(), errmsg);
 }
 
 json_io_exception::json_io_exception(exception_type et, size_t s) noexcept : json_exception(et)

--- a/utf8.cpp
+++ b/utf8.cpp
@@ -26,6 +26,8 @@
 #include "utf8.hpp"
 #include "json_utf8_exception.hpp"
 
+#include <stdint.h> // uint8_t
+
 using namespace NAMESPACE;
 
 static unsigned int utf8_from_hex(char c)


### PR DESCRIPTION
Uses the return value of strerror_r rather than the temporary buffer directly as glibc now sometimes returns pointers to static storage without writing to the buffer https://linux.die.net/man/3/strerror_r.
Reserves space for the null terminator written by strncpy to resolve warning `specified bound 200 equals destination size [-Wstringop-truncation]`
Includes `<stdint.h>` for `uint8_t` as glibc/libstdc++ no longer makes the typedefs visible without explicit inclusion of the header.
Bumps the minimum supported cmake version to 3.5 to resolve the configure error
```
CMake Error at CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.5 has been removed from CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.

  Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.
```